### PR TITLE
fix(RE-5): remove obsolete tests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -70,7 +70,10 @@ lazy val redactedTests = (project in file("tests"))
   .settings(scalafixSettings)
   .settings(
     publish / skip := true,
-    libraryDependencies ++= Seq("org.scalatest" %% "scalatest" % "3.2.17" % Test),
+    libraryDependencies ++= Seq(
+      "org.scalatest"     %% "scalatest"       % "3.2.17"   % Test,
+      "org.scalatestplus" %% "scalacheck-1-17" % "3.2.17.0" % Test
+    ),
     scalacOptions ++= {
       val jar = (redactedCompilerPlugin / assembly).value
       val addPlugin = "-Xplugin:" + jar.getAbsolutePath

--- a/tests/src/test/scala/io/github/polentino/redacted/RedactedSpec.scala
+++ b/tests/src/test/scala/io/github/polentino/redacted/RedactedSpec.scala
@@ -9,42 +9,47 @@ class RedactedSpec extends AnyFlatSpec {
 
   behavior of "@redacted"
 
-  it should "work with case classes without user-defined companion object" in {
-    val name: String = "Berfu"
-    val age = 26
-    val email: String = "berfu@gmail.com"
-    val expected = s"RedactionWithoutCompanionObj(***,$age,***)"
+  it should "work with a redacted case class of just one member" in {
+    case class OneMember(@redacted name: String)
+    val name = "berfu"
+    val expected = "OneMember(***)"
 
-    val testing = RedactionWithoutCompanionObj(name, age, email)
+    val testing = OneMember(name)
     val implicitToString = s"$testing"
     val explicitToString = testing.toString
-    val cp = new Checkpoint
 
+    val cp = new Checkpoint
     cp { assert(implicitToString == expected) }
     cp { assert(explicitToString == expected) }
-    cp { assert(testing.name == name && testing.age == age && testing.email == email) }
+    cp { assert(testing.name == name) }
     cp.reportAll()
   }
 
-  it should "work with case classes with user-defined companion object" in {
-    val name: String = "Berfu"
-    val age = 26
-    val email: String = "berfu@gmail.com"
-    val expected = s"RedactionWithCompanionObj(***,$age,***)"
+  it should "work with a redacted case class with many members" in {
+    case class ManyMembers(field1: String, @redacted field2: String, @redacted field3: String, field4: String)
+    val field1 = "field-1"
+    val field2 = "field-2"
+    val field3 = "field-3"
+    val field4 = "field-4"
+    val expected = s"ManyMembers($field1,***,***,$field4)"
 
-    val testing = RedactionWithCompanionObj(name, age, email)
+    val testing = ManyMembers(field1, field2, field3, field4)
     val implicitToString = s"$testing"
     val explicitToString = testing.toString
-    val cp = new Checkpoint
 
+    val cp = new Checkpoint
     cp { assert(implicitToString == expected) }
     cp { assert(explicitToString == expected) }
-    cp { assert(testing.name == name && testing.age == age && testing.email == email) }
-    cp { assert(RedactionWithCompanionObj.something == 123) }
+    cp {
+      assert(testing.field1 == field1 &&
+        testing.field2 == field2 &&
+        testing.field3 == field3 &&
+        testing.field4 == field4)
+    }
     cp.reportAll()
   }
 
-  it should "work with nested case classes in object" in {
+  it should "work with nested case classes" in {
     val id = "id-1"
     val name1 = "Diego"
     val age1 = 999
@@ -57,7 +62,6 @@ class RedactedSpec extends AnyFlatSpec {
     val explicitToString = testing.toString
 
     val cp = new Checkpoint
-
     cp { assert(implicitToString == expected) }
     cp { assert(explicitToString == expected) }
     cp {
@@ -73,7 +77,6 @@ class RedactedSpec extends AnyFlatSpec {
   it should "work with nested case classes in case class" in {
     case class Inner(userId: String, @redacted balance: Int)
     case class Outer(inner: Inner)
-
     val userId = "user-123"
     val balance = 123_456_789
     val expected = s"Outer(Inner($userId,***))"
@@ -83,7 +86,6 @@ class RedactedSpec extends AnyFlatSpec {
     val explicitToString = testing.toString
 
     val cp = new Checkpoint
-
     cp { assert(implicitToString == expected) }
     cp { assert(explicitToString == expected) }
     cp {
@@ -92,23 +94,6 @@ class RedactedSpec extends AnyFlatSpec {
           testing.inner.balance == balance
       )
     }
-    cp.reportAll()
-  }
-
-  it should "work with a redacted case class of just one member" in {
-    case class OneMember(@redacted name: String)
-    val name = "berfu"
-    val expected = "OneMember(***)"
-
-    val testing = OneMember(name)
-    val implicitToString = s"$testing"
-    val explicitToString = testing.toString
-
-    val cp = new Checkpoint
-
-    cp { assert(implicitToString == expected) }
-    cp { assert(explicitToString == expected) }
-    cp { assert(testing.name == name) }
     cp.reportAll()
   }
 }

--- a/tests/src/test/scala/io/github/polentino/redacted/RedactedSpec.scala
+++ b/tests/src/test/scala/io/github/polentino/redacted/RedactedSpec.scala
@@ -2,98 +2,109 @@ package io.github.polentino.redacted
 
 import org.scalatest.Checkpoints.*
 import org.scalatest.flatspec.AnyFlatSpec
-
 import io.github.polentino.redacted.RedactionWithNestedCaseClass.Inner
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 
-class RedactedSpec extends AnyFlatSpec {
+import java.util.UUID
+
+class RedactedSpec extends AnyFlatSpec with ScalaCheckPropertyChecks {
 
   behavior of "@redacted"
 
   it should "work with a redacted case class of just one member" in {
     case class OneMember(@redacted name: String)
-    val name = "berfu"
-    val expected = "OneMember(***)"
 
-    val testing = OneMember(name)
-    val implicitToString = s"$testing"
-    val explicitToString = testing.toString
+    forAll { (name: String) =>
+      val expected = "OneMember(***)"
+      val testing = OneMember(name)
+      val implicitToString = s"$testing"
+      val explicitToString = testing.toString
 
-    val cp = new Checkpoint
-    cp { assert(implicitToString == expected) }
-    cp { assert(explicitToString == expected) }
-    cp { assert(testing.name == name) }
-    cp.reportAll()
+      val cp = new Checkpoint
+      cp { assert(implicitToString == expected) }
+      cp { assert(explicitToString == expected) }
+      cp { assert(testing.name == name) }
+      cp.reportAll()
+    }
   }
 
   it should "work with a redacted case class with many members" in {
     case class ManyMembers(field1: String, @redacted field2: String, @redacted field3: String, field4: String)
-    val field1 = "field-1"
-    val field2 = "field-2"
-    val field3 = "field-3"
-    val field4 = "field-4"
-    val expected = s"ManyMembers($field1,***,***,$field4)"
 
-    val testing = ManyMembers(field1, field2, field3, field4)
-    val implicitToString = s"$testing"
-    val explicitToString = testing.toString
+    forAll { (field1: String, field2: String, field3: String, field4: String) =>
+      val expected = s"ManyMembers($field1,***,***,$field4)"
+      val testing = ManyMembers(field1, field2, field3, field4)
+      val implicitToString = s"$testing"
+      val explicitToString = testing.toString
 
-    val cp = new Checkpoint
-    cp { assert(implicitToString == expected) }
-    cp { assert(explicitToString == expected) }
-    cp {
-      assert(testing.field1 == field1 &&
-        testing.field2 == field2 &&
-        testing.field3 == field3 &&
-        testing.field4 == field4)
+      val cp = new Checkpoint
+      cp { assert(implicitToString == expected) }
+      cp { assert(explicitToString == expected) }
+      cp {
+        assert(testing.field1 == field1 &&
+          testing.field2 == field2 &&
+          testing.field3 == field3 &&
+          testing.field4 == field4)
+      }
+      cp.reportAll()
     }
-    cp.reportAll()
   }
 
-  it should "work with nested case classes" in {
-    val id = "id-1"
-    val name1 = "Diego"
-    val age1 = 999
-    val name2 = "Berfu"
-    val age2 = 888
-    val expected = s"RedactionWithNestedCaseClass($id,***,Inner(***,$age2))"
+  it should "work with case class nested in companion object" in {
+    forAll { (id: String, name1: String, age1: Int, name2: String, age2: Int) =>
+      val expected = s"RedactionWithNestedCaseClass($id,***,Inner(***,$age2))"
+      val testing = RedactionWithNestedCaseClass(id, Inner(name1, age1), Inner(name2, age2))
+      val implicitToString = s"$testing"
+      val explicitToString = testing.toString
 
-    val testing = RedactionWithNestedCaseClass(id, Inner(name1, age1), Inner(name2, age2))
-    val implicitToString = s"$testing"
-    val explicitToString = testing.toString
-
-    val cp = new Checkpoint
-    cp { assert(implicitToString == expected) }
-    cp { assert(explicitToString == expected) }
-    cp {
-      assert(testing.id == id &&
-        testing.inner1.name == name1 &&
-        testing.inner1.age == age1 &&
-        testing.inner2.name == name2 &&
-        testing.inner2.age == age2)
+      val cp = new Checkpoint
+      cp { assert(implicitToString == expected) }
+      cp { assert(explicitToString == expected) }
+      cp {
+        assert(testing.id == id &&
+          testing.inner1.name == name1 &&
+          testing.inner1.age == age1 &&
+          testing.inner2.name == name2 &&
+          testing.inner2.age == age2)
+      }
+      cp.reportAll()
     }
-    cp.reportAll()
   }
 
   it should "work with nested case classes in case class" in {
     case class Inner(userId: String, @redacted balance: Int)
     case class Outer(inner: Inner)
-    val userId = "user-123"
-    val balance = 123_456_789
-    val expected = s"Outer(Inner($userId,***))"
 
-    val testing = Outer(Inner(userId, balance))
-    val implicitToString = s"$testing"
-    val explicitToString = testing.toString
+    forAll { (userId: String, balance: Int) =>
+      val expected = s"Outer(Inner($userId,***))"
+      val testing = Outer(Inner(userId, balance))
+      val implicitToString = s"$testing"
+      val explicitToString = testing.toString
 
-    val cp = new Checkpoint
-    cp { assert(implicitToString == expected) }
-    cp { assert(explicitToString == expected) }
-    cp {
-      assert(
-        testing.inner.userId == userId &&
-          testing.inner.balance == balance
-      )
+      val cp = new Checkpoint
+      cp { assert(implicitToString == expected) }
+      cp { assert(explicitToString == expected) }
+      cp {
+        assert(
+          testing.inner.userId == userId &&
+            testing.inner.balance == balance
+        )
+      }
+      cp.reportAll()
     }
-    cp.reportAll()
+  }
+
+  it must "not change the behavior of `hashCode`" in {
+    final case class TestClass(uuid: UUID, name: String, age: Int)
+    object RedactedTestClass {
+      final case class TestClass(uuid: UUID, @redacted name: String, @redacted age: Int)
+    }
+
+    forAll { (uuid: UUID, name: String, age: Int) =>
+      val testClass = TestClass(uuid, name, age)
+      val redactedTestClass = RedactedTestClass.TestClass(uuid, name, age)
+
+      assert(testClass.hashCode() == redactedTestClass.hashCode())
+    }
   }
 }

--- a/tests/src/test/scala/io/github/polentino/redacted/RedactionWithCompanionObj.scala
+++ b/tests/src/test/scala/io/github/polentino/redacted/RedactionWithCompanionObj.scala
@@ -1,9 +1,0 @@
-package io.github.polentino.redacted
-
-import io.github.polentino.redacted.redacted
-
-case class RedactionWithCompanionObj(@redacted name: String, age: Int, @redacted email: String)
-
-object RedactionWithCompanionObj {
-  val something = 123
-}

--- a/tests/src/test/scala/io/github/polentino/redacted/RedactionWithoutCompanionObj.scala
+++ b/tests/src/test/scala/io/github/polentino/redacted/RedactionWithoutCompanionObj.scala
@@ -1,5 +1,0 @@
-package io.github.polentino.redacted
-
-import io.github.polentino.redacted.redacted
-
-case class RedactionWithoutCompanionObj(@redacted name: String, age: Int, @redacted email: String)


### PR DESCRIPTION
The tests still contained obsolete ones, dating back when the compiler plugin was adding an extra `__redactedFields` variable in the companion object of the case class being redacted.

Since this is not happening anymore, those tests aren't relevant anymore.

Also. adding some test to showcase that `hashCode` isn't affected by the redaction.